### PR TITLE
rpc/httpkit: send inline disposition for pdf documents

### DIFF
--- a/clouwayapis/rpc/httpkit/http.go
+++ b/clouwayapis/rpc/httpkit/http.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/clouway/go-genproto/clouwayapis/rpc/fileserve"
@@ -22,7 +23,10 @@ func UnmarshalJSON(b []byte, m proto.Message) error {
 // the response as JSON to the response writer. Primarily useful in a server.
 func EncodeHTTPGenericResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
 	if f, ok := response.(*fileserve.BinaryFile); ok {
-		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", f.FileName))
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", url.QueryEscape(f.FileName)))
+		if f.ContentType == "application/pdf" {
+			w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=%s", url.QueryEscape(f.FileName)))
+		}
 		w.Header().Set("Content-Type", f.ContentType)
 		w.Write(f.Content)
 		return nil

--- a/clouwayapis/rpc/httpkit/http_test.go
+++ b/clouwayapis/rpc/httpkit/http_test.go
@@ -55,7 +55,36 @@ func TestEncodeBinaryFile(t *testing.T) {
 		t.Errorf("unexpected Content-Type header:\n- want: %v\n-  got: %v", wantContentType, contentType)
 		return
 	}
+}
 
+func TestEncodePDFDocument(t *testing.T) {
+	protoResponse := &fileserve.BinaryFile{ContentType: "application/pdf", FileName: "MyDoc.pdf", Content: []byte("::content::")}
+
+	w := httptest.NewRecorder()
+	httpkit.EncodeHTTPGenericResponse(context.Background(), w, protoResponse)
+
+	b, _ := ioutil.ReadAll(w.Result().Body)
+	contentDisposition := w.Header().Get("Content-Disposition")
+	contentType := w.Header().Get("Content-Type")
+
+	wantContentType := "application/pdf"
+	wantContentDisposition := "inline; filename=MyDoc.pdf"
+	want := []byte("::content::")
+
+	if !reflect.DeepEqual(want, b) {
+		t.Errorf("unexpected binary response of EncodeHTTPGenericResponse:\n- want: %v\n-  got: %v", want, b)
+		return
+	}
+
+	if contentDisposition != wantContentDisposition {
+		t.Errorf("unexpected Content-Disposition header:\n- want: %v\n-  got: %v", wantContentDisposition, contentDisposition)
+		return
+	}
+
+	if wantContentType != contentType {
+		t.Errorf("unexpected Content-Type header:\n- want: %v\n-  got: %v", wantContentType, contentType)
+		return
+	}
 }
 
 func TestEncodeHTTPGenericResponseWithEmptySlice(t *testing.T) {


### PR DESCRIPTION
The backend will now send inline disposition for pdf documents to ensure that browser is able to render it inline instead of forcing the user to download the document.